### PR TITLE
Replace cURL for HTTP requests

### DIFF
--- a/classes/UserProfileShortcode.php
+++ b/classes/UserProfileShortcode.php
@@ -20,6 +20,7 @@ class UserProfileShortcode {
 
     public function waUserProfileShortcode($args, $content = null)
     {
+        // get user id from shortcode arguments
         $userID_arg = $this->extractAndRemoveUserID($args);
         if(empty($_REQUEST['user-id']) && !$userID_arg) {
             return;
@@ -46,7 +47,7 @@ class UserProfileShortcode {
 
         $waService = new WAService();
         $current_user_id = get_user_meta(get_current_user_id(), "wawp_wa_user_id");
-        $contacts;
+        // $contacts;
         if($userID == $current_user_id) { //If user being displayed is the current user
             $contacts = $waService->getContactsList($filter, $select, false); //run without restriction
         } else {

--- a/classes/WaApiClient.php
+++ b/classes/WaApiClient.php
@@ -1,7 +1,9 @@
 <?php
 namespace PO\classes;
 
-use WAWP\Data_Encryption;
+use \WAWP\Log as Log;
+use \WAWP\Data_Encryption;
+use \WAWP\WA_API;
 $path = wp_normalize_path(ABSPATH . 'wp-content/plugins/Wild-Apricot-Press/src/class-data-encryption.php');
 
 require_once ($path);
@@ -10,60 +12,33 @@ require_once ($path);
 class WaApiClient
 {
     const AUTH_URL = 'https://oauth.wildapricot.org/auth/token';
+    const USER_AGENT = 'WildApricotPress/1.0';
 
-    private $tokenScope = 'auto';
-
-    private static $_instance;
+    private $wa_api;
     private $token;
 
-    // public function __construct($apiKey) {
-
-    //   if (!extension_loaded('curl')) {
-    //     throw new \Exception('cURL library is not loaded');
-    //   }
-    //   $this->initTokenByApiKey($apiKey);
-    // }
-
-    // TODO: try/catch
     public function __construct() {
-        $apiKey = $this->getApiKey();
-        $this->initTokenByApiKey($apiKey);
+        try {
+            $this->initToken();
+        } catch (\Exception $e) {
+            Log::wap_log_error($e->getMessage(), 1);
+        }
     }
 
-    private function getApiKey() {
+    public function getAccountID() {
         $dataEncryption = new Data_Encryption();
-        $credentials = get_option('wawp_wal_name');
-        if (empty($credentials)) {
-            throw new \Exception("WildApricot API Keys not configured.");
-        }
-        $e_apiKey = $credentials['wawp_wal_api_key'];
-        $d_apiKey = $dataEncryption->decrypt($e_apiKey);
-        return $d_apiKey;
+
+        $account_id_e = get_transient(\WAWP\WA_Integration::ADMIN_ACCOUNT_ID_TRANSIENT);
+        $account_id = $dataEncryption->decrypt($account_id_e);
+
+        return $account_id;
     }
 
-    public function initTokenByContactCredentials(
-        $userName,
-        $password,
-        $scope = null
-    ) {
-        if ($scope) {
-            $this->tokenScope = $scope;
-        }
-
-        $this->token = $this->getAuthTokenByAdminCredentials(
-            $userName,
-            $password
-        );
-        if (!$this->token) {
-            throw new \Exception('Unable to get authorization token.');
-        }
+    public function initToken() {
+        $access_data = WA_API::verify_valid_access_token();
+        $this->wa_api = new WA_API($access_data['access_token'], $access_data['account_id']);
+        $this->token = $access_data['access_token'];
     }
-
-    public function initTokenByApiKey($apiKey, $scope = null)
-    {
-        if ($scope) {
-            $this->tokenScope = $scope;
-        }
 
     public function makeRequest($url, $isPicture = false, $verb = 'GET', $data = array())
     {
@@ -110,26 +85,8 @@ class WaApiClient
             throw new \Exception('failed making request');
         }
 
-        $result = json_decode($response, true);
-        curl_close($ch);
-        return $result['access_token'];
+        return json_decode($response_data, true);
     }
-
-    // public static function getInstance()
-    // {
-    //     if (!is_object(self::$_instance)) {
-    //         self::$_instance = new self();
-    //     }
-
-    //     return self::$_instance;
-    // }
-
-    // final public function __clone()
-    // {
-    //     throw new Exception(
-    //         'It\'s impossible to clone singleton "' . __CLASS__ . '"!'
-    //     );
-    // }
 
     public function __destruct()
     {

--- a/classes/WaApiClient.php
+++ b/classes/WaApiClient.php
@@ -4,9 +4,6 @@ namespace PO\classes;
 use \WAWP\Log as Log;
 use \WAWP\Data_Encryption;
 use \WAWP\WA_API;
-$path = wp_normalize_path(ABSPATH . 'wp-content/plugins/Wild-Apricot-Press/src/class-data-encryption.php');
-
-require_once ($path);
 // From:
 //  s://github.com/WildApricot/ApiSamples/blob/master/PHP/sampleApplication.php
 class WaApiClient


### PR DESCRIPTION
Resolves part of #22 
- Use WP's build in request library
- Clean up unused code
- Utilize more API functions from the core plugin
  - Obtain access token and accound ID from the saved transients in the options table instead of making a separate request
  - We can always assume core is installed and activated when the member directory is in use